### PR TITLE
Improve CVec API 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: rust
 sudo: false
 script:
   - rustc --version
-  - cargo build
+  - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "Apache-2.0/MIT"
 [lib]
 name = "c_vec"
 crate-type = ["dylib", "rlib"]
+
+[dev-dependencies]
+libc = "0.1"

--- a/src/c_vec.rs
+++ b/src/c_vec.rs
@@ -170,20 +170,20 @@ impl<'b, T> AsSlice<T> for CVec<'b, T> {
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
+    extern crate alloc;
+    extern crate libc;
 
     use super::CVec;
-    use libc;
-    use ptr;
+    use std::ptr;
 
-    fn malloc(n: uint) -> CVec<u8> {
+    fn malloc(n: usize) -> CVec<'static, u8> {
         unsafe {
-            let mem = ptr::Unique(libc::malloc(n as libc::size_t));
-            if mem.0.is_null() { ::alloc::oom() }
+            let mem = ptr::Unique::new(libc::malloc(n as libc::size_t));
+            if (*mem).is_null() { alloc::oom() }
 
-            CVec::new_with_dtor(mem.0 as *mut u8,
+            CVec::new_with_dtor(*mem as *mut u8,
                                 n,
-                                move|| { libc::free(mem.0 as *mut libc::c_void); })
+                                move|| { libc::free((*mem) as *mut libc::c_void); })
         }
     }
 
@@ -223,11 +223,11 @@ mod tests {
     #[test]
     fn test_unwrap() {
         unsafe {
-            let cv = CVec::new_with_dtor(1 as *mut int,
+            let cv = CVec::new_with_dtor(1 as *mut isize,
                                          0,
                                          move|| panic!("Don't run this destructor!"));
             let p = cv.into_inner();
-            assert_eq!(p, 1 as *mut int);
+            assert_eq!(p, 1 as *mut isize);
         }
     }
 


### PR DESCRIPTION
- Require `Unique` pointers in `CVec` constructors (this kinda is required by `as_mut_slice` and when using a destructor).
- Change the user-defined destructor bound to be `FnOnce(*mut T) + 'static`, that is it's not allowed to have captured any borrowed references and its argument is the pointer that was passed to the constructor.
- Thanks to the above remove the lifetime parameter on `CVec`.
