### PR TITLE
Nightly updates

### DIFF
--- a/src/c_vec.rs
+++ b/src/c_vec.rs
@@ -33,6 +33,7 @@
 //! if necessary.
 
 #![feature(unsafe_destructor, std_misc, unique, convert)]
+#![cfg_attr(test, feature(alloc))]
 
 use std::ptr;
 use std::slice;
@@ -309,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn vec_test_panic_at_null() {
         unsafe {
             CVec::new(Unique::new(ptr::null_mut::<u8>()), 9);
@@ -317,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn slice_test_panic_at_null() {
         unsafe {
             CSlice::new(ptr::null_mut::<u8>(), 9);
@@ -332,7 +333,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn slice_test_overrun_get() {
         let cs = s_malloc(16);
 
@@ -359,16 +360,14 @@ mod tests {
 
     #[test]
     fn vec_to_slice_test() {
-        unsafe {
-            let mut cv = v_malloc(2);
+        let mut cv = v_malloc(2);
 
-            *cv.get_mut(0).unwrap() = 10;
-            *cv.get_mut(1).unwrap() = 12;
-            let cs = cv.as_cslice();
+        *cv.get_mut(0).unwrap() = 10;
+        *cv.get_mut(1).unwrap() = 12;
+        let cs = cv.as_cslice();
 
-            assert_eq!(cs[0], 10);
-            assert_eq!(cs[1], 12);
-        }
+        assert_eq!(cs[0], 10);
+        assert_eq!(cs[1], 12);
     }
 
     #[test]

--- a/src/c_vec.rs
+++ b/src/c_vec.rs
@@ -240,16 +240,16 @@ impl<T> AsSlice<T> for CSlice<T> {
 impl<T> Index<usize> for CSlice<T> {
     type Output = T;
 
-    fn index<'a>(&'a self, _index: &usize) -> &'a T {
-        assert!(*_index < self.len);
-        unsafe { &*self.base.offset(*_index as isize) }
+    fn index<'a>(&'a self, _index: usize) -> &'a T {
+        assert!(_index < self.len);
+        unsafe { &*self.base.offset(_index as isize) }
     }
 }
 
 impl<T> IndexMut<usize> for CSlice<T> {
-    fn index_mut<'a>(&'a mut self, _index: &usize) -> &'a mut T {
-        assert!(*_index < self.len);
-        unsafe { &mut *self.base.offset(*_index as isize) }
+    fn index_mut<'a>(&'a mut self, _index: usize) -> &'a mut T {
+        assert!(_index < self.len);
+        unsafe { &mut *self.base.offset(_index as isize) }
     }
 }
 


### PR DESCRIPTION
- The `Index` traits have changed signatures.
- `AsSlice` is deprecated in favour of `AsRef`/`AsMut`.
- Fix the tests.
