### PR TITLE
Remove redundant crate-type declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0/MIT"
 
 [lib]
 name = "c_vec"
-crate-type = ["dylib", "rlib"]
 
 [dev-dependencies]
 libc = "0.1"


### PR DESCRIPTION
The rustc compiler now automatically figures out what kind of lib to build.
